### PR TITLE
GetUserPaymentRequest expects ISO-8601 Zulu

### DIFF
--- a/src/PHPTikkie.php
+++ b/src/PHPTikkie.php
@@ -1,6 +1,7 @@
 <?php
 namespace PHPTikkie;
 
+use DateTime;
 use DateTimeInterface;
 use PHPTikkie\Entities\PaymentRequest;
 use PHPTikkie\Entities\Platform;
@@ -64,11 +65,15 @@ class PHPTikkie
         $params = compact('offset', 'limit');
 
         if ($fromDate) {
-            $params['fromDate'] = $fromDate->format('c');
+            $params['fromDate'] = (new DateTime())->setTimestamp($fromDate->getTimestamp())
+                ->setTimezone('UTC')
+                ->format('Y-m-d\TH:i:s\Z');
         }
 
         if ($toDate) {
-            $params['toDate'] = $toDate->format('c');
+            $params['toDate'] = (new DateTime())->setTimestamp($toDate->getTimestamp())
+                ->setTimezone('UTC')
+                ->format('Y-m-d\TH:i:s\Z');
         }
 
         $response = $this->environment->getRequest("/v1/tikkie/platforms/{$platformToken}/users/{$userToken}/paymentrequests", $params);

--- a/src/PHPTikkie.php
+++ b/src/PHPTikkie.php
@@ -3,6 +3,7 @@ namespace PHPTikkie;
 
 use DateTime;
 use DateTimeInterface;
+use DateTimeZone;
 use PHPTikkie\Entities\PaymentRequest;
 use PHPTikkie\Entities\Platform;
 use PHPTikkie\Entities\User;
@@ -66,13 +67,13 @@ class PHPTikkie
 
         if ($fromDate) {
             $params['fromDate'] = (new DateTime())->setTimestamp($fromDate->getTimestamp())
-                ->setTimezone('UTC')
+                ->setTimezone(new DateTimeZone('UTC'))
                 ->format('Y-m-d\TH:i:s\Z');
         }
 
         if ($toDate) {
             $params['toDate'] = (new DateTime())->setTimestamp($toDate->getTimestamp())
-                ->setTimezone('UTC')
+                ->setTimezone(new DateTimeZone('UTC'))
                 ->format('Y-m-d\TH:i:s\Z');
         }
 


### PR DESCRIPTION
Using ->format('c') does produce an ISO-8601 string [as the documentation states it requires](https://developer.abnamro.com/api/tikkie/technical-details#get-user-payment-request), but in reality as the example states, it expects a ISO-8601-Zulu string, so using this will produce an invalid input error.

Creating a new datetime object feels a bit dirty, but sadly the setTimezone() function does not exist on the DateTimeInterface and I didn't want to change the method contract.