### PR TITLE
Exception message now contains traceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ use PHPTikkie\Exceptions\PHPTikkieException;
 try {
     var_dump($tikkie->platforms());
 } catch (PHPTikkieException $exception) {
-    print $exception->getMessage(); // [ERR_2005_002] The API Key is invalid for the requested resource (see https://developer.abnamro.com/get-started#obtaining-an-api-key)
+    print $exception->getMessage(); // [ERR_2005_002] The API Key is invalid for the requested resource | traceId: 6fda2ce8-225d-4ca2-920a-b687c7aeb2f3 | (see https://developer.abnamro.com/get-started#obtaining-an-api-key)
 }

--- a/src/Exceptions/PHPTikkieException.php
+++ b/src/Exceptions/PHPTikkieException.php
@@ -22,7 +22,9 @@ abstract class PHPTikkieException extends RuntimeException
             if (count($this->errors) > 0) {
                 $error = $this->errors[0];
 
-                $message = "[{$error->code}] {$error->message} (see {$error->reference})";
+                $message = "[{$error->code}] {$error->message} "
+                    . "| traceId: {$error->traceId} | "
+                    . "(see {$error->reference})";
             }
         }
 

--- a/tests/CreatePaymentRequestTest.php
+++ b/tests/CreatePaymentRequestTest.php
@@ -29,7 +29,7 @@ class CreatePaymentRequestTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->newPaymentRequest()->save();
     }

--- a/tests/CreatePlatformTest.php
+++ b/tests/CreatePlatformTest.php
@@ -33,7 +33,7 @@ class CreatePlatformTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->newPlatform()->save();
     }

--- a/tests/CreateUserTest.php
+++ b/tests/CreateUserTest.php
@@ -43,7 +43,7 @@ class CreateUserTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->newUser()->save();
     }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -20,7 +20,7 @@ class EnvironmentTest extends TestCase
         $this->setMockHttpResponse('InvalidApiKey.txt');
 
         $this->expectException(AccessTokenException::class);
-        $this->expectExceptionMessage("[ERR_2005_001] The API Key is invalid (see https://developer.abnamro.com/get-started#obtaining-an-api-key)");
+        $this->expectExceptionMessage("[ERR_2005_001] The API Key is invalid | traceId: 98de8459-377d-4834-a0a2-079f94f0f43d | (see https://developer.abnamro.com/get-started#obtaining-an-api-key)");
 
         $this->tikkie->newPlatform()->save();
     }

--- a/tests/FetchPaymentRequestTest.php
+++ b/tests/FetchPaymentRequestTest.php
@@ -48,7 +48,7 @@ class FetchPaymentRequestTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->tikkie->paymentRequest('platformtoken1', 'usertoken1', 'paymentrequesttoken1');
     }

--- a/tests/FetchPaymentRequestsTest.php
+++ b/tests/FetchPaymentRequestsTest.php
@@ -58,7 +58,7 @@ class FetchPaymentRequestsTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->tikkie->paymentRequests('platformtoken1', 'usertoken1', 0, 10);
     }

--- a/tests/FetchPlatformsTest.php
+++ b/tests/FetchPlatformsTest.php
@@ -36,7 +36,7 @@ class FetchPlatformsTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->tikkie->platforms();
     }

--- a/tests/FetchUsersTest.php
+++ b/tests/FetchUsersTest.php
@@ -42,7 +42,7 @@ class FetchUsersTest extends TestCase
         $this->setMockHttpResponse(['AccessToken.txt', 'ValidationError.txt']);
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage("[ERR_1100_004] Field validation error (see https://developer.abnamro.com/api/tikkie/technical-details)");
+        $this->expectExceptionMessage("[ERR_1100_004] Field validation error | traceId: 3cbf4bc9-108c-4e02-ad6e-937c79d875e3 | (see https://developer.abnamro.com/api/tikkie/technical-details)");
 
         $this->tikkie->users('platformtoken1');
     }


### PR DESCRIPTION
This is to be able to request more information from the Tikkie provider about that transaction to help uncover why it failed.

Also updated the tests to reflect the change.