### PR TITLE
externalId is no longer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ $paymentRequest = $tikkie->newPaymentRequest($platformToken, $userToken, $bankAc
     'amountInCents' => '1250',
     'currency' => 'EUR',
     'description' => 'Thank you',
-
-    // Optional attributes
     'externalId' => 'Order 1234'
 ])->save();
 


### PR DESCRIPTION
After a endless back-and-forth with ABN it became clear they made the externalId mandatory:
https://developer.abnamro.com/api/tikkie-v1/technical-details